### PR TITLE
Update PCRE version to 8.42

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -74,7 +74,7 @@ fi
 cd $build_dir
 
 status "Downloading and installing pcre"
-pcre_version=${PCRE_VER:-8.36}
+pcre_version=${PCRE_VER:-8.42}
 curl ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-$pcre_version.tar.gz | tar xzf - -C $build_dir/vendor
 mkdir $build_dir/vendor/pcre
 


### PR DESCRIPTION
Updates the `pcre_version` variable to use the latest available release
available from ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/.
The previously specified version (8.36) is no longer available.

Fixes #1.